### PR TITLE
Fixed error when using authorize payment type

### DIFF
--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -130,7 +130,8 @@ class Gateway extends BaseGateway
         $previousMode = $view->getTemplateMode();
         $view->setTemplateMode(View::TEMPLATE_MODE_CP);
 
-        $view->registerJsFile('https://www.paypal.com/sdk/js?client-id=' . Craft::parseEnv($this->clientId), ['data-namespace' => 'paypal_checkout_sdk']);
+        $intent = self::PAYMENT_TYPES[$this->paymentType] === 'AUTHORIZE' ? '&intent=authorize' : '';
+        $view->registerJsFile('https://www.paypal.com/sdk/js?client-id=' . Craft::parseEnv($this->clientId) . $intent, ['data-namespace' => 'paypal_checkout_sdk']);
         // IE polyfill
         $view->registerJsFile('https://polyfill.io/v3/polyfill.min.js?features=fetch%2CPromise%2CPromise.prototype.finally');
         $view->registerAssetBundle(PayPalCheckoutBundle::class);


### PR DESCRIPTION
Got the following error when using PayPal with payment type set to authorize:

> Expected intent from order api call to be capture, got authorize. Please ensure you are passing intent=authorize to the sdk url.

Need to append `&intent=authorize` to the sdk URL when registering the JS file.