### PR TITLE
Return the error string message on error after submitting PayPal Checkout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added string error message when an error occurs after the submitting payment information to PayPal Checkout.
+
 ### Fixed
 - Fixed a bug where the PayPal Checkout gateway was incorrectly showing in the available gateways list for CP payments. ([#30](https://github.com/craftcms/commerce-paypal-checkout/issues/30))
 

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -31,10 +31,18 @@ function initPaypalCheckout() {
                     return res.json();
                 }).then(function(data) {
                     if (data.error) {
-                        var error = JSON.parse(data.error);
-                        if (error.details && error.details.length) {
-                            throw Error(error.details[0].description);
+                        var errorMessage = '';
+                        
+                        try {
+                            var error = JSON.parse(data.error);
+                            if (error.details && error.details.length) {
+                                errorMessage = error.details[0].description;
+                            }
+                        } catch (e) {
+                            errorMessage = data.error;
                         }
+                            
+                        throw Error(errorMessage);
                     }
                     transactionHash = data.transactionHash;
                     return data.transactionId; // Use the same key name for order ID on the client and server

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -34,11 +34,13 @@ function initPaypalCheckout() {
                         var errorMessage = '';
                         
                         try {
+                            // Handle PayPal errors
                             var error = JSON.parse(data.error);
                             if (error.details && error.details.length) {
                                 errorMessage = error.details[0].description;
                             }
                         } catch (e) {
+                            // Handle Commerce errors
                             errorMessage = data.error;
                         }
                             


### PR DESCRIPTION
Added string error message when an error occurs after the submitting payment information to PayPal Checkout.