### PR TITLE
Allow “locale” parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-- Added string error message when an error occurs after the submitting payment information to PayPal Checkout.
+### Added
+- Added the `locale` parameter for when customizing the PayPal SDK script. ([#123](https://github.com/craftcms/commerce-paypal-checkout/pull/35))
+
+### Fixed
+- Fixed a bug where Commerce payment errors weren’t being returned
 
 ### Fixed
 - Fixed a bug where the PayPal Checkout gateway was incorrectly showing in the available gateways list for CP payments. ([#30](https://github.com/craftcms/commerce-paypal-checkout/issues/30))

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This is required when paying with an alternative payment currency due to the int
 
 This gateway allows the passing of certain query string parameters, at runtime, as specified in the [PayPal documentation](https://developer.paypal.com/docs/checkout/reference/customize-sdk/#query-parameters).
 
-THe allowed parameters are `currency` (as detailed above), `locale`, `disable-card` and `disable-funding`.
+The allowed parameters are `currency` (as detailed above), `disable-card`, `disable-funding` and `locale`.
 
 As an example to disable PayPal credit funding you could output the payment form as follows:
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This is required when paying with an alternative payment currency due to the int
 
 This gateway allows the passing of certain query string parameters, at runtime, as specified in the [PayPal documentation](https://developer.paypal.com/docs/checkout/reference/customize-sdk/#query-parameters).
 
-THe allowed parameters are `currency` (as detailed above), `disable-card` and `disable-funding`.
+THe allowed parameters are `currency` (as detailed above), `locale`, `disable-card` and `disable-funding`.
 
 As an example to disable PayPal credit funding you could output the payment form as follows:
 

--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -737,10 +737,10 @@ class Gateway extends BaseGateway
     private function _sdkQueryParameters(Array $passedParams): string
     {
         $passedParamsMergeKeys = [
-            'locale',
             'currency',
             'disable-card',
             'disable-funding',
+            'locale',
         ];
         $intent = strtolower(self::PAYMENT_TYPES[$this->paymentType]);
         $params = [

--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -737,6 +737,7 @@ class Gateway extends BaseGateway
     private function _sdkQueryParameters(Array $passedParams): string
     {
         $passedParamsMergeKeys = [
+            'locale',
             'currency',
             'disable-card',
             'disable-funding',


### PR DESCRIPTION
PayPal is currently using the wrong language using Safari if the user is not logged in with their PayPal account.

In my case, using Chrome, the PayPal popup shows the Italian language (correct).

Using Safari, the PayPal popup shows the English language (wrong). I have already verified that the language setting on Safari was "Italian".

Using the PayPal "locale" parameter it is at least possible to force the language to be used in the popup.