### PR TITLE
Update readme to not use deprecated command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd /path/to/my-project.test
 composer require craftcms/commerce-paypal-checkout
 
 # tell Craft to install the plugin
-./craft install/plugin commerce-paypal-checkout
+./craft plugin/install commerce-paypal-checkout
 ```
 
 ## Setup


### PR DESCRIPTION
Avoinding the big red

`The install/plugin command is deprecated.    
        Running plugin/install instead...  `

when following the instructions.