### PR TITLE
Allow to provide custom payment urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,17 @@ For example, to disable PayPal credit funding you could output the payment form 
   ...
 }) }}
 ```
+
+### Use custom payment urls
+
+If custom payment urls are needed, they can be provided by using `prepareUrl` and `completeUrl`. One common use-case for that, is setting the used site.
+
+```cart
+{% namespace cart.gateway.handle|commercePaymentFormNamespace %}
+  {{ cart.gateway.getPaymentFormHtml({
+    currency: cart.paymentCurrency,
+    prepareUrl: actionUrl('commerce/payments/pay', {'siteToken': currentSite.id|hash }),
+    completeUrl: actionUrl('commerce/payments/complete-payment', {'siteToken': currentSite.id|hash }),
+  })|raw }}
+{% endnamespace %}
+```

--- a/src/templates/paymentForm.html
+++ b/src/templates/paymentForm.html
@@ -1,5 +1,5 @@
 <div class="paypal-rest-form" data-env="{{ gateway.testMode ? 'sandbox' : 'production' }}"
-     data-prepare="{{ actionUrl('commerce/payments/pay') }}"
-     data-complete="{{ actionUrl('commerce/payments/complete-payment') }}">
+     data-prepare="{{ prepareUrl ?? actionUrl('commerce/payments/pay') }}"
+     data-complete="{{ completeUrl ?? actionUrl('commerce/payments/complete-payment') }}">
   <div id="paypal-button-container"></div>
 </div>


### PR DESCRIPTION
### Description

My website is losing track of the used site, when using the PayPal-Gateway. By allowing to set the `siteToken` from the outside, I was able to fix that.

### Related issues

 #67