### PR TITLE
Fixed: DECLINED status in payment

### DIFF
--- a/src/responses/CheckoutResponse.php
+++ b/src/responses/CheckoutResponse.php
@@ -59,28 +59,29 @@ class CheckoutResponse implements RequestResponseInterface
             
             $this->status = self::STATUS_SUCCESSFUL;
 
-            if (isset($this->data->result->purchase_units) && isset($this->data->result->purchase_units->payments)) {
+            if (isset($this->data->result->purchase_units) && isset($this->data->result->purchase_units[0]->payments)) {
                 
                 $captureStatus = null;
                 $authorizeStatus = null;
 
-                if (!empty($this->data->result->purchase_units->payments->captures)) {
-                    $captureStatus = $this->data->result->purchase_units->payments->captures[0]->status;
+                if (!empty($this->data->result->purchase_units[0]->payments->captures)) {
+                    $captureStatus = $this->data->result->purchase_units[0]->payments->captures[0]->status;
                 }
 
-                if (!empty($this->data->result->purchase_units->payments->authorizations)) {
-                    $authorizeStatus = $this->data->result->purchase_units->payments->authorizations[0]->status;
+                if (!empty($this->data->result->purchase_units[0]->payments->authorizations)) {
+                    $authorizeStatus = $this->data->result->purchase_units[0]->payments->authorizations[0]->status;
                 }
 
                 if ($captureStatus == 'PENDING' || $authorizeStatus == 'PENDING') {
                     $this->status = self::STATUS_PROCESSING;
                 }
 
-                if ($captureStatus == 'DECLINED' || $authorizeStatus == 'DECLINED') {
+                if ($captureStatus == 'DECLINED' || $authorizeStatus == 'DECLINED' || $captureStatus == 'FAILED' || $authorizeStatus == 'FAILED') {
                     $this->status = self::STATUS_ERROR;
                 }
                 
             }
+
         } elseif ($this->data && isset($this->data->result->status) && $this->data->result->status == self::STATUS_ERROR) {
             $this->status = self::STATUS_ERROR;
         }

--- a/src/responses/CheckoutResponse.php
+++ b/src/responses/CheckoutResponse.php
@@ -56,9 +56,11 @@ class CheckoutResponse implements RequestResponseInterface
         $this->status = self::STATUS_REDIRECT;
 
         if ($this->data && ($this->data->result && is_object($this->data->result)) && (isset($this->data->result->status) && $this->data->result->status == 'COMPLETED')) {
+            
             $this->status = self::STATUS_SUCCESSFUL;
 
             if (isset($this->data->result->purchase_units) && isset($this->data->result->purchase_units->payments)) {
+                
                 $captureStatus = null;
                 $authorizeStatus = null;
 
@@ -73,6 +75,11 @@ class CheckoutResponse implements RequestResponseInterface
                 if ($captureStatus == 'PENDING' || $authorizeStatus == 'PENDING') {
                     $this->status = self::STATUS_PROCESSING;
                 }
+
+                if ($captureStatus == 'DECLINED' || $authorizeStatus == 'DECLINED') {
+                    $this->status = self::STATUS_ERROR;
+                }
+                
             }
         } elseif ($this->data && isset($this->data->result->status) && $this->data->result->status == self::STATUS_ERROR) {
             $this->status = self::STATUS_ERROR;


### PR DESCRIPTION
### Description

(NOTE: I accidentally marked this to commit to 3.x branch, but it should be 2.x branch)

We had an issue where PayPal reported the order as COMPLETED, but the payment was marked as DECLINED. Which still resulted in the order being marked as successful.

Checking to see if the captureStatus is DECLINED fixes this:

<img width="1972" height="1064" alt="CleanShot 2025-09-25 at 14 46 42@2x" src="https://github.com/user-attachments/assets/41405508-55e6-4e2c-9da0-745bacdc8c72" />

<img width="1194" height="768" alt="CleanShot 2025-09-25 at 14 47 09@2x" src="https://github.com/user-attachments/assets/2434b095-72cc-4dfd-bf53-78b1bc77b8df" />

<img width="1272" height="400" alt="CleanShot 2025-09-25 at 14 47 41@2x" src="https://github.com/user-attachments/assets/a0a42cc7-4368-4a3f-9ae8-5407570cf59a" />